### PR TITLE
fix: initial datatable lib not work

### DIFF
--- a/src/main/sas/MainMonotonicFirstBining.sas
+++ b/src/main/sas/MainMonotonicFirstBining.sas
@@ -17,10 +17,11 @@ DATA work.german_credit_card ;
 RUN ;
 
 /*for init parameter*/
+%let data_table_lib = WORK ;
 %let data_table = german_credit_card;
 %let y = default;
 /*  Age Creditamount durationinmonth existingcredits Installmentrate presentresidence numberofpeople */
-%let x =Age Creditamount durationinmonth existingcredits Installmentrate presentresidence numberofpeople;
+%let x =Creditamount ;
 %let exclude_condi = <= -99999999;
 %let init_sign = auto ;
 %let min_samples = %sysevalf(1000 * 0.05); /* <<<<<  1000 means the rows of the dataset */
@@ -31,7 +32,7 @@ RUN ;
 %let is_using_encoding_var = 1;
 
 /*for MFB*/
-%init(data_table = &data_table., y = &y., x = &x., exclude_condi = &exclude_condi., init_sign = &init_sign., 
+%init(data_table_lib = &data_table_lib., data_table = &data_table., y = &y., x = &x., exclude_condi = &exclude_condi., init_sign = &init_sign., 
       min_samples = &min_samples., min_bads = &min_bads., min_pvalue = &min_pvalue., 
       show_woe_plot = &show_woe_plot.,
       is_using_encoding_var = &is_using_encoding_var., lib_name = &lib_name.);
@@ -54,4 +55,3 @@ RUN ;
 
 /*clean data table ex:bins_summary/bins_summary_pvalue/exclude/...etc.*/
 %cleanBinsDetail(bins_lib = &lib_name.);
-

--- a/src/main/sas/MainSizeFirstBining.sas
+++ b/src/main/sas/MainSizeFirstBining.sas
@@ -19,10 +19,11 @@ RUN ;
 PROC DATASETS lib = TMPWOE kill ; QUIT ;RUN ;
 
 /*for init parameter*/
+%let data_table_lib = WORK ;
 %let data_table = german_credit_card;
 %let y = default;
 /*  Age Creditamount durationinmonth existingcredits Installmentrate presentresidence numberofpeople */
-%let x =Age Creditamount durationinmonth existingcredits Installmentrate presentresidence numberofpeople;
+%let x = Creditamount;
 %let exclude_condi = <= -99999999;
 %let init_sign = auto ;
 %let min_samples = %sysevalf(1000 * 0.05); /* <<<<<  1000 means the rows of the dataset */
@@ -36,7 +37,7 @@ PROC DATASETS lib = TMPWOE kill ; QUIT ;RUN ;
 %let min_bins = 3;
 %let max_samples = %sysevalf(1000 * 0.4); /* <<<<<  1000 means the rows of the dataset */
 
-%init(data_table = &data_table., y = &y., x = &x., exclude_condi = &exclude_condi., init_sign = &init_sign., 
+%init(data_table_lib = &data_table_lib., data_table = &data_table., y = &y., x = &x., exclude_condi = &exclude_condi., init_sign = &init_sign., 
       min_samples = &min_samples., min_bads = &min_bads., min_pvalue = &min_pvalue., 
       show_woe_plot = &show_woe_plot.,
       is_using_encoding_var = &is_using_encoding_var., lib_name = &lib_name.);

--- a/src/main/sas/mob/num/BinsSummary.sas
+++ b/src/main/sas/mob/num/BinsSummary.sas
@@ -64,16 +64,16 @@
 	%do %while(1);
 		%let i = 0;
 		DATA &lib_name..bins_summary_&x.;
-		SET &lib_name..bins_summary_&x.;
-		tmpidx = _n_ - 1;
-		drop idx ;
-		rename tmpidx = idx ;
-		WHERE del_flg = 0;
+			SET &lib_name..bins_summary_&x.;
+			tmpidx = _n_ - 1;
+			drop idx ;
+			rename tmpidx = idx ;
+			WHERE del_flg = 0;
 		RUN;
 		
 		PROC SQL NOPRINT;
-	 	SELECT COUNT(*) INTO :record_size 
-	      FROM &lib_name..bins_summary_&x.;
+			SELECT COUNT(*) INTO :record_size 
+			FROM &lib_name..bins_summary_&x.;
 		QUIT;
 
 		%do %while(1);
@@ -82,12 +82,12 @@
 			%if &j. >= &record_size. %then %goto finished_bin_i_check;
 			
 			PROC SQL NOPRINT;
-			SELECT means into :mean_i
-			  FROM &lib_name..bins_summary_&x. 
-             WHERE idx = &i.;
-			SELECT means into :mean_j 
-			  FROM &lib_name..bins_summary_&x. 
-             WHERE idx = &j.;
+				SELECT means into :mean_i
+				FROM &lib_name..bins_summary_&x. 
+				WHERE idx = &i.;
+				SELECT means into :mean_j 
+				FROM &lib_name..bins_summary_&x. 
+				WHERE idx = &j.;
 			QUIT;
 			
 			%if &mean_i. &sign. &mean_j. %then 
@@ -107,14 +107,14 @@
 						%if &bins_size_est. < &min_bins. %then %goto finished_bin_i_check;
 
 						PROC SQL NOPRINT;
-						SELECT nsamples,means, std_dev INTO :nsamples_i, :nmeans_i, :nstd_i
-						  FROM &lib_name..bins_summary_&x.
-			             WHERE idx = &i.;
-						SELECT nsamples,means, std_dev INTO :nsamples_j, :nmeans_j, :nstd_j
-						  FROM &lib_name..bins_summary_&x.
-			             WHERE idx = &j.;
-					
+							SELECT nsamples,means, std_dev INTO :nsamples_i, :nmeans_i, :nstd_i
+							FROM &lib_name..bins_summary_&x.
+							WHERE idx = &i.;
+							SELECT nsamples,means, std_dev INTO :nsamples_j, :nmeans_j, :nstd_j
+							FROM &lib_name..bins_summary_&x.
+							WHERE idx = &j.;
 						QUIT;  
+
 						%let group_samples = %sysevalf(&nsamples_j. + &nsamples_i);
 						%let group_means = %sysevalf((%sysevalf(&nsamples_j. * &nmeans_j.) + %sysevalf(&nsamples_i. * &nmeans_i.)) / &group_samples.);
 
@@ -142,12 +142,12 @@
 						%if &j. >= &record_size. %then %goto finished_bin_j_check;
 						
 						PROC SQL NOPRINT;
-						SELECT means into :tmpmean_i
-						  FROM &lib_name..bins_summary_&x. 
-			             WHERE idx = &i.;
-						SELECT means into :tmpmean_j 
-						  FROM &lib_name..bins_summary_&x. 
-			             WHERE idx = &j.;
+							SELECT means into :tmpmean_i
+							FROM &lib_name..bins_summary_&x. 
+							WHERE idx = &i.;
+							SELECT means into :tmpmean_j 
+							FROM &lib_name..bins_summary_&x. 
+							WHERE idx = &j.;
 						QUIT;
 
 						%if &tmpmean_i. &sign. &tmpmean_j. %then 
@@ -164,10 +164,10 @@
 		%finished_bin_i_check:
 
 		PROC SQL NOPRINT;
-		SELECT SUM(del_flg) into :dels 
-		  FROM &lib_name..bins_summary_&x.;
+			SELECT SUM(del_flg) into :dels 
+		  	FROM &lib_name..bins_summary_&x.;
 		QUIT;
-/* 		%put dels = &dels.; */
+		/* %put dels = &dels.; */
 
 		%if &dels. = 0 %then %goto finished_bin;
 	%end;
@@ -175,7 +175,7 @@
 	
 	/*combine exclude result*/
 	DATA &lib_name..bins_summary_&x.;
-	SET &lib_name..bins_summary_&x. work.init_summary_exclude;
+		SET &lib_name..bins_summary_&x. work.init_summary_exclude;
 	RUN;
 %MEND;
 
@@ -234,25 +234,25 @@
 	QUIT;
 
 	DATA &lib_name..bins_summary_&x.;
-	SET work.init_summary;
-	std_dev = COALESCE(std_dev, 0);
-	idx = _n_ - 1;
+		SET work.init_summary;
+		std_dev = COALESCE(std_dev, 0);
+		idx = _n_ - 1;
 	RUN;
 	
 	%let del_count = 0;
 	%do %while(1);
 		%let i = 0;
 		DATA &lib_name..bins_summary_&x.;
-		SET &lib_name..bins_summary_&x.;
-		tmpidx = _n_ - 1;
-		drop idx ;
-		rename tmpidx = idx ;
-		WHERE del_flg = 0;
+			SET &lib_name..bins_summary_&x.;
+			tmpidx = _n_ - 1;
+			drop idx ;
+			rename tmpidx = idx ;
+			WHERE del_flg = 0;
 		RUN;
 		
 		PROC SQL NOPRINT;
-	 	SELECT COUNT(*) INTO :record_size 
-	      FROM &lib_name..bins_summary_&x.;
+			SELECT COUNT(*) INTO :record_size 
+			FROM &lib_name..bins_summary_&x.;
 		QUIT;
 
 		%do %while(1);
@@ -261,12 +261,12 @@
 			%if &j. >= &record_size. %then %goto finished_bin_i_check;
 			
 			PROC SQL NOPRINT;
-			SELECT means into :mean_i
-			  FROM &lib_name..bins_summary_&x. 
-             WHERE idx = &i.;
-			SELECT means into :mean_j 
-			  FROM &lib_name..bins_summary_&x. 
-             WHERE idx = &j.;
+				SELECT means into :mean_i
+				FROM &lib_name..bins_summary_&x. 
+				WHERE idx = &i.;
+				SELECT means into :mean_j 
+				FROM &lib_name..bins_summary_&x. 
+				WHERE idx = &j.;
 			QUIT;
 			
 			%if &mean_i. &sign. &mean_j. %then 
@@ -283,6 +283,7 @@
 							SELECT nsamples, means, std_dev INTO :nsamples_i, :nmeans_i, :nstd_i
 						  	FROM &lib_name..bins_summary_&x.
 			             	WHERE idx = &i.;
+							
 							SELECT nsamples, means, std_dev INTO :nsamples_j, :nmeans_j, :nstd_j
 						  	FROM &lib_name..bins_summary_&x.
 			             	WHERE idx = &j.;
@@ -316,6 +317,7 @@
 							SELECT means into :tmpmean_i
 						  	FROM &lib_name..bins_summary_&x. 
 			             	WHERE idx = &i.;
+							
 							SELECT means into :tmpmean_j 
 						  	FROM &lib_name..bins_summary_&x. 
 			             	WHERE idx = &j.;
@@ -336,9 +338,9 @@
 
 		PROC SQL NOPRINT;
 			SELECT SUM(del_flg) into :dels 
-		  	FROM &lib_name..bins_summary_&x.;
+			FROM &lib_name..bins_summary_&x.;
 		QUIT;
-/* 		%put dels = &dels.; */
+		/* %put dels = &dels.; */
 
 		%if &dels. = 0 %then %goto finished_bin;
 	%end;
@@ -346,6 +348,6 @@
 	
 	/*combine exclude result*/
 	DATA &lib_name..bins_summary_&x.;
-	SET &lib_name..bins_summary_&x. work.init_summary_exclude;
+		SET &lib_name..bins_summary_&x. work.init_summary_exclude;
 	RUN;
 %MEND;


### PR DESCRIPTION
fix the situation if the dataset is not stored in `work` library, the encoding var table will not find the columns list from `dictionary.columns`